### PR TITLE
poly-infra-amous manage_dev, rds fetch / local restore snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ terraform/.terraform
 terraform/.terraform.lock.hcl
 test.log
 test.sqlite
+roombaht*.sql.gz
 
 # Created by https://www.toptal.com/developers/gitignore/api/vim,emacs,python,react
 # Edit at https://www.toptal.com/developers/gitignore?templates=vim,emacs,python,react

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ frontend_archive: frontend_build
 
 
 # targets to support local non-containerized development environments
-frontend_dev: frontend_build
+local_frontend_dev: frontend_build
 	docker run -ti \
 		-p 3000:3000 \
 		-u node \
@@ -77,8 +77,9 @@ local_backend_migrations: local_backend_env
 local_sample_data: local_backend_env
 	./scripts/sample_data.sh
 
-local_backend_clean_data:
-	rm -rf backend/db.sqlite3
+# wipes database, works with both local and docker compose variant
+backend_clean_data:
+	./scripts/manage_dev flush --no-input
 
 # clean up build artifacts and such
 local_backend_distclean: local_backend_clean local_backend_clean_data
@@ -97,3 +98,4 @@ distclean: local_backend_distclean frontend_clean
 
 # testing shortcut
 test: local_backend_tests
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 services:
   backend:
     build:
@@ -11,6 +12,7 @@ services:
       - docker-dev.env
     depends_on:
       - db
+
   backend-test:
     build:
       context: ./backend
@@ -23,6 +25,7 @@ services:
       - docker-test.env
     depends_on:
       - db
+
   frontend:
     build:
       context: ./frontend
@@ -34,8 +37,9 @@ services:
     command: /app/scripts/entrypoint-compose.sh
     depends_on:
       - backend
+
   db:
-    image: postgres:16.4-alpine3.20
+    image: postgres:16
     ports:
       - 5432:5432
     volumes:

--- a/scripts/manage_dev
+++ b/scripts/manage_dev
@@ -4,16 +4,24 @@ set -e
 
 SCRIPTDIR=$( cd "${0%/*}" && pwd)
 ROOTDIR="${SCRIPTDIR%/*}"
-if [ -n "$ROOMBAHT_CONFIG" ] ; then
-    echo "Using alternative config ${ROOMBAHT_CONFIG}"
-    if [ ! -e "$ROOMBAHT_CONFIG" ] ; then
-	echo "Unable to open alternate config, lollll"
-	exit 2
-    fi
-else
-    ROOMBAHT_CONFIG="${ROOTDIR}/dev.env"
-fi
-source "$ROOMBAHT_CONFIG"
 
-"${ROOTDIR}/backend/.venv/bin/python" \
-    "${ROOTDIR}/backend/manage.py" "$@"
+if docker compose ps | grep -q roombot-backend ; then
+    docker compose run \
+	   -v "${ROOTDIR}:${ROOTDIR}" \
+	   --rm \
+	   backend \
+	   uv run /usr/src/app/manage.py "$@"
+else
+    if [ -n "$ROOMBAHT_CONFIG" ] ; then
+	echo "Using alternative config ${ROOMBAHT_CONFIG}"
+	if [ ! -e "$ROOMBAHT_CONFIG" ] ; then
+	    echo "Unable to open alternate config, lollll"
+	    exit 2
+	fi
+    else
+	ROOMBAHT_CONFIG="${ROOTDIR}/dev.env"
+    fi
+    source "$ROOMBAHT_CONFIG"
+    "${ROOTDIR}/backend/.venv/bin/python" \
+	"${ROOTDIR}/backend/manage.py" "$@"
+fi

--- a/scripts/provision-remote.sh
+++ b/scripts/provision-remote.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-PACKAGES=(aptitude nginx screen python3 virtualenv certbot python3-certbot-nginx postgresql-client htop iftop build-essential python3-dev libpq-dev jq postgresql-server-dev-all)
+PACKAGES=(aptitude nginx screen python3 virtualenv certbot python3-certbot-nginx postgresql-client htop iftop build-essential python3-dev libpq-dev jq postgresql-server-dev-all docker.io)
 UV_VERSION="0.9.2"
-UV_CHECKSUM="b775bb84c72210c6c0b9670cfaad0ac2e3953f12a2947d52b57603b4fbae3798"
 
 set -e
 
@@ -87,6 +86,7 @@ python_freshen
 add_user gadget otakup0pe
 add_user index Index01
 add_user cubes cubes
+add_user whiteavian whiteavian
 
 add_user roombaht
 lock_user ubuntu
@@ -94,3 +94,4 @@ lock_user ubuntu
 sudo_user gadget
 sudo_user index
 sudo_user cubes
+sudo_user whiteavian

--- a/scripts/restore_snapshot.sh
+++ b/scripts/restore_snapshot.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPTDIR=$( cd "${0%/*}" && pwd)
+ROOTDIR="${SCRIPTDIR%/*}"
+
+problems() {
+    2>&1 echo "Error: $*"
+    exit 1
+}
+
+usage() {
+    cat <<EOF
+Usage: $0 <snapshot.sql|snapshot.sql.gz>
+
+Options:
+  -h             Show this help
+
+Examples:
+  $0 ./roombaht-staging-01011969-0420.sql.gz
+EOF
+}
+
+info() { echo "==> $*"; }
+
+if [ -f "${ROOTDIR}/docker-dev.env" ]; then
+    # shellcheck disable=SC1090
+    source "${ROOTDIR}/docker-dev.env"
+else
+    problems "Missing ${ROOTDIR}/docker-dev.env, rip"
+fi
+
+SNAPSHOT_FILE="${1-}"
+[ -n "$SNAPSHOT_FILE" ] || { usage; problems "Missing snapshot file argument"; }
+[ -f "$SNAPSHOT_FILE" ] || problems "Snapshot file not found: $SNAPSHOT_FILE"
+
+# Decide how to stream the snapshot
+if [[ "$SNAPSHOT_FILE" == *.gz ]]; then
+    STREAM_CMD="gunzip -c '$SNAPSHOT_FILE'"
+else
+    STREAM_CMD="cat '$SNAPSHOT_FILE'"
+fi
+
+# even locally, it can take a minute for the db to come back to life
+wait_for_db_accepting_connections() {
+    local db="$1"
+    local i allow
+    local RETRIES=30
+    local SLEEP_SECONDS=1
+
+    for i in $(seq 1 "$RETRIES"); do
+        allow="$(run_psql postgres "SELECT datallowconn FROM pg_database WHERE datname = '$db';" || true)"
+        allow="$(echo "$allow" | tr -d '[:space:]' || true)"
+
+        if [ "$allow" = "t" ]; then
+            if docker compose exec -T db psql -U "$POSTGRES_USER" -d "$db" -c '\q' >/dev/null 2>&1; then
+                return 0
+            fi
+        elif [ "$allow" = "f" ]; then
+            echo "Database '$db' exists but disallows connections; attempting to enable..."
+            run_psql postgres "ALTER DATABASE \"${db}\" WITH ALLOW_CONNECTIONS = true;" || true
+        else
+            if docker compose exec -T db psql -U "$POSTGRES_USER" -d "$db" -c '\q' >/dev/null 2>&1; then
+                return 0
+            fi
+        fi
+
+        sleep "$SLEEP_SECONDS"
+    done
+
+    return 1
+}
+
+run_psql() {
+    db="$1"
+    sql="$2"
+    docker compose exec -T db psql -U "$POSTGRES_USER" -d "$db" -v ON_ERROR_STOP=1 -q -A -t -c "$sql"
+}
+
+# # Revoke connects, terminate any backends, drop and create the DB
+
+# * kick connections and block for now
+# * drop and re-create the database
+info "Dropping and recreating database '$POSTGRES_DB' (connecting to 'postgres' for maintenance)..."
+run_psql postgres "REVOKE CONNECT ON DATABASE \"$POSTGRES_DB\" FROM public;" >/dev/null 2>&1 || true
+run_psql postgres "ALTER DATABASE \"$POSTGRES_DB\" CONNECTION LIMIT 0;" >/dev/null 2>&1 || true
+run_psql postgres "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '$(echo "$POSTGRES_DB" | sed "s/'/''/g")' AND pid <> pg_backend_pid();" >/dev/null 2>&1 || true
+run_psql postgres "DROP DATABASE IF EXISTS \"$POSTGRES_DB\";" >/dev/null 2>&1 || true
+run_psql postgres "CREATE DATABASE \"$POSTGRES_DB\";" >/dev/null 2>&1 || true
+wait_for_db_accepting_connections "$POSTGRES_DB"
+
+# "translate" any roles set in RDS to be usable locally
+# relatively conservative fetching of roles from OWNER TO, CREATE ROLE, SET ROLE
+info "Scanning snapshot for referenced roles and ensuring they exist in the cluster..."
+ROLES_TMP="$(mktemp)"
+trap 'rm -f "$ROLES_TMP"' EXIT
+
+set +o errexit
+# todo something other than eval heh
+eval "$STREAM_CMD" | \
+  grep -oE -e "OWNER TO[[:space:]]*['\"]?[A-Za-z0-9_]+" \
+            -e "CREATE ROLE[[:space:]]*['\"]?[A-Za-z0-9_]+" \
+            -e "SET ROLE[[:space:]]*['\"]?[A-Za-z0-9_]+" \
+  | sed -E "s/^(OWNER TO|CREATE ROLE|SET ROLE)[[:space:]]*['\"]?([A-Za-z0-9_]+).*/\2/" \
+  | sort -u > "$ROLES_TMP" || true
+set -o errexit
+
+while read -r role; do
+    [ -z "$role" ] && continue
+    # skip obvious existing roles
+    if [ "$role" = "$POSTGRES_USER" ] || [ "$role" = "postgres" ]; then
+        continue
+    fi
+    info "Ensuring role '$role' exists..."
+    # Create role if missing; use a DO block to avoid errors if it already exists.
+    run_psql postgres "DO \$\$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '$role') THEN CREATE ROLE \"$role\" LOGIN; END IF; END \$\$;" >/dev/null 2>&1 || true
+done < "$ROLES_TMP"
+
+info "Restoring snapshot into database '$POSTGRES_DB'..."
+eval "$STREAM_CMD" | docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1
+info "Restore complete 🎺"
+exit 0

--- a/scripts/roombaht_ctl
+++ b/scripts/roombaht_ctl
@@ -30,6 +30,7 @@ Actions:
   backend-restart                Restart the roombaht systemd service
   snapshot                       Create a DB snapshot on the remote host
   snapshot-list                  List available DB snapshots on the remote host
+  snapshot-fetch                 Create and fetch a DB snapshot from the remote host
   wipe                           Wipe the remote ROOMBAHT_DB (interactive confirmation)
   clone_db [options] <source>    Clone a source database into ROOMBAHT_DB (interactive)
                                  Options are forwarded to the remote script. For example:
@@ -152,6 +153,23 @@ elif [ "$ACTION" == "snapshot" ] ; then
 elif [ "$ACTION" == "snapshot-list" ] ; then
     yeet_script
     yeet_ctl "${ACTION} snapshot-list"
+elif [ "$ACTION" == "snapshot-fetch" ] ; then
+    if [ -n "$1" ] ; then
+	CMD="snapshot-fetch $1"
+    else
+	CMD="snapshot-fetch"
+    fi
+    yeet_script
+    # * run command and capture output (hence not using yeet_ctl)
+    # * make sure remote file exists, and fetch
+    # * clean up after ourselves
+    OUTPUT=$(ssh -o 'ControlMaster no' "${SSH_HOST}" "sudo bash -c 'export ENV_FILE=/tmp/${R_SECRET} ; bash /tmp/${R_SCRIPT} ${CMD}'; sudo rm -f /tmp/${R_SCRIPT} /tmp/${R_SECRET}") || true
+    REMOTE_PATH="$(echo "$OUTPUT" | tail -n1 | tr -d '\r')"
+    if [ -z "$REMOTE_PATH" ] ; then
+        problems "remote did not produce snapshot path. Output was: $OUTPUT"
+    fi
+    scp -q "${SSH_HOST}:${REMOTE_PATH}" .
+    ssh -o 'ControlMaster no' "${SSH_HOST}" "sudo rm -f '${REMOTE_PATH}'" >/dev/null 2>&1 || true
 elif [ "$ACTION" == "wipe" ] || [ "$ACTION" == "clone_db" ] ; then
     if [ "$R_ENV" == "prod" ] ; then
         if [ "$ACTION" == "wipe" ] ; then


### PR DESCRIPTION
* `manage_dev` now attempts to connect to the `backend` docker compose service, falling back to "local mode"
  * note it mounts the project directory as a volume in the container, for commands such as `create_rooms`
* new `snapshot-fetch` (pairs well with `snapshot-list`) `roombaht_ctl` command to generate and download a psql dump
* new `./scripts/restore_snapshot.sh` script for yeeting ⬆️ snapshots into docker compose `db` service
* adding @whiteavian to deployed hosts